### PR TITLE
deleting old files properly; fixed logic

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -25,12 +25,11 @@
 # Run this by
 # sudo bash python.sh 3.11.0
 # or via github by
-# wget -qO - https://raw.githubusercontent.com/tvdsluijs/raspberry_python_sh_install/main/python.sh | sudo bash -s 3.10.0
+# wget -qO - https://raw.githubusercontent.com/tvdsluijs/sh-python-installer/main/python.sh | sudo bash -s 3.10.0
 
 set -euo pipefail
 
 install_python () {
-
     new_version="$1"
     py_main_version=${new_version::-2}
     file="Python-${new_version}.tar.xz"
@@ -70,11 +69,17 @@ install_python () {
 
     echo "Let's cleanup!"
     cd ..
-    rm -r ${Python-$new_version}
-    rm -rf ${file}
+    rm -rf "Python-$new_version"
+    rm -r ${file}
+
+    echo "Let's install PIP"
+    apt -qq install -y python3-pip < /dev/null
+
+    echo "updating pip..."
+    python${py_main_version} -m pip install --upgrade pip
 
     new_python_version=$(python -c 'import platform; print(platform.python_version())')
-    if [ $old_python_version = $new_version ]; then
+    if [ $new_python_version = $new_version ]; then
         echo "Version okay!"
     else
         echo "Okay, let's try to get your new installed to be the default!"
@@ -82,14 +87,10 @@ install_python () {
         update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${py_main_version} 1
     fi
 
-    echo "Let's install PIP"
-    apt -qq install -y python3-pip < /dev/null
-
     clear
     echo "All Done!"
     echo "Your new Python version should be ${new_version}"
     echo "You can check this yourself by 'python --version'"
-    echo "It might be a good idea to update pip with : 'python pip install --upgrade pip'"
     echo ""
     echo "Do not forget to give me a tip/donation for my hard :-) work!"
     echo "https://itheo.tech/donate"


### PR DESCRIPTION
I had to update some RPI's' python to 3.10.0 and found this script. I then found some minor bugs in the code which lead to crashing the script. I (hopefully) fixed following problems:
- updated the path to this repository in the script
- not properly deleting old files (wrong naming + no "rf" parameter while deleting a directory) -> fixes #6 
- logic problem (when checking if the current python version is the updated one, the wrong variables are compared)
- moved the part which sets the new python version as default to the end of the script (had some errors when not doing this)
- updating pip automatically

tested with 3.9.2 -> 3.10.0
